### PR TITLE
feat: add direct source download support for raw datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For reproducibility purposes, specific versions of this repository were used in 
 ## Features
 
 - Provides a unified interface for handling vibrational data
-- Includes five public datasets: 
+- Includes five seven datasets: 
     - CWRU - Case Western Reserve University Bearing Dataset;
     - IMS - Intelligent Maintenance System Bearing Dataset;
     - UOC - University of Connecticut Gearbox Dataset;

--- a/vibdata/raw/CWRU/CWRU.py
+++ b/vibdata/raw/CWRU/CWRU.py
@@ -1,294 +1,44 @@
 import os
 from typing import Dict, Union
+from urllib.error import URLError
+from urllib.request import urlretrieve, Request, urlopen
+import requests
+import time
 
 import numpy as np
 import pandas as pd
 from scipy.io import loadmat
 
+from bs4 import BeautifulSoup
+import re
+
+
 from vibdata.raw.base import DownloadableDataset, RawVibrationDataset
-from vibdata.raw.utils import _get_package_resource_dataframe
+from vibdata.raw.utils import _get_package_resource_dataframe, check_integrity
 from vibdata.definitions import LABELS_PATH
 
 
 class CWRU_raw(RawVibrationDataset, DownloadableDataset):
-    DATAFILE_NAMES = [
-        # normal
-        ["97.mat"],
-        ["98.mat"],
-        ["99.mat"],
-        ["100.mat"],
-        # For 12k Drive End Bearing Fault Data
-        [
-            "105.mat",
-            "118.mat",
-            "130.mat",
-            "169.mat",
-            "185.mat",
-            "197.mat",
-            "209.mat",
-            "222.mat",
-            "234.mat",
-        ],  # 1797rpm
-        [
-            "106.mat",
-            "119.mat",
-            "131.mat",
-            "170.mat",
-            "186.mat",
-            "198.mat",
-            "210.mat",
-            "223.mat",
-            "235.mat",
-        ],  # 1772rpm
-        [
-            "107.mat",
-            "120.mat",
-            "132.mat",
-            "171.mat",
-            "187.mat",
-            "199.mat",
-            "211.mat",
-            "224.mat",
-            "236.mat",
-        ],  # 1750rpm
-        [
-            "108.mat",
-            "121.mat",
-            "133.mat",
-            "172.mat",
-            "188.mat",
-            "200.mat",
-            "212.mat",
-            "225.mat",
-            "237.mat",
-        ],  # 1730rpm
-        # For 12k Fan End Bearing Fault Data
-        [
-            "278.mat",
-            "282.mat",
-            "294.mat",
-            "274.mat",
-            "286.mat",
-            "310.mat",
-            "270.mat",
-            "290.mat",
-            "315.mat",
-        ],  # 1797rpm
-        [
-            "279.mat",
-            "283.mat",
-            "295.mat",
-            "275.mat",
-            "287.mat",
-            "309.mat",
-            "271.mat",
-            "291.mat",
-            "316.mat",
-        ],  # 1772rpm
-        [
-            "280.mat",
-            "284.mat",
-            "296.mat",
-            "276.mat",
-            "288.mat",
-            "311.mat",
-            "272.mat",
-            "292.mat",
-            "317.mat",
-        ],  # 1750rpm
-        [
-            "281.mat",
-            "285.mat",
-            "297.mat",
-            "277.mat",
-            "289.mat",
-            "312.mat",
-            "273.mat",
-            "293.mat",
-            "318.mat",
-        ],  # 1730rpm
-        # For 48k Drive End Bearing Fault Data
-        [
-            "109.mat",
-            "122.mat",
-            "135.mat",
-            "174.mat",
-            "189.mat",
-            "201.mat",
-            "213.mat",
-            "250.mat",
-            "262.mat",
-        ],  # 1797rpm
-        [
-            "110.mat",
-            "123.mat",
-            "136.mat",
-            "175.mat",
-            "190.mat",
-            "202.mat",
-            "214.mat",
-            "251.mat",
-            "263.mat",
-        ],  # 1772rpm
-        [
-            "111.mat",
-            "124.mat",
-            "137.mat",
-            "176.mat",
-            "191.mat",
-            "203.mat",
-            "215.mat",
-            "252.mat",
-            "264.mat",
-        ],  # 1750rpm
-        [
-            "112.mat",
-            "125.mat",
-            "138.mat",
-            "177.mat",
-            "192.mat",
-            "204.mat",
-            "217.mat",
-            "253.mat",
-            "265.mat",
-        ],  # 1730rpm
-    ]
-    ALLNAMES = [item for sublist in DATAFILE_NAMES for item in sublist]
-
-    MD5SUMS = [
-        "ee410e7243aefcd8b7120876556464e7",
-        "3983dcddead0d4b910ee1e8d3da164b9",
-        "edc080a0b4fbc0c2ec8b7f1403372b73",
-        "cc57a511b95785c805055d99281ea2bb",
-        "f14821b40412f33018279198da7f9cdc",
-        "ff0f20588edc64140ae33888fcf1114a",
-        "e45f73f65cc3de4482d28d758503f2c1",
-        "09e41b26825d87e03908add7f01d21aa",
-        "e9121cec5988ffd8b33b855371e03ba5",
-        "9109c26832e82a904fd8545eebe4c05c",
-        "a6c8deded8d592ded19818d001687abc",
-        "9e572db7bcdd0690fed770fcd29d07ca",
-        "e95df8c8a6fc455d9cea5c2ca36fdc38",
-        "4abe03d02739813eebc879b20b591968",
-        "ba784233ebbe424e31bb35c5523413cd",
-        "8053f13c15bb8891dd7586466e72fb34",
-        "3b6eb7ba1276995006d2754a821cbe54",
-        "29d343340eba96cc3ce4777a3952a30b",
-        "376e134d452b25fcd95c2cf4f5c5b93d",
-        "fd00ce7a23af6324b1f8aa7784eda37a",
-        "df865596a366f545a4b6f5869bdd1531",
-        "6d19ac8a0a37e74a19ed6c6dbd150f79",
-        "2bf7a32b6b59aa379d5a4a3c345418f5",
-        "89fbf0d771512d848972fd574d3923e8",
-        "cf1a7ab3e14564be490c7c27bfafed78",
-        "22a48a1c32a58fe320cef89119b8b0d9",
-        "4f290b5d8f16d466c96f665ccdb08b08",
-        "bfe060099052eeb4f3081c80194cc40e",
-        "49e63eb2b41faf93ff8452d4fffe8773",
-        "b710aabecd66dc21b4f28db4ac968a0a",
-        "92947302ba4198102894daf7613e5fff",
-        "ccec995fde6f8865632972804dadfc55",
-        "7715250229a6d47910d12be7e1970e70",
-        "796a8db507869acf5e0b880d0925f693",
-        "5acfb2d067d71a084272b832246c3ae9",
-        "04728be1ecfd77e106e0371dedc460bb",
-        "e57c5e90335671a2302ebb8f3c626509",
-        "bf7c1d5702c18f85f54934bbcbb468c0",
-        "523ac0bfb09515c73001d3fbb97a4ffd",
-        "cafb20bc696fc025ef42cf12eaf986e3",
-        "65bb377a01906b61be2f9d82027abffb",
-        "b3815a01a53b7f98bd0162726409c593",
-        "bd3b8c05a01b46b5114c582023771f0a",
-        "8fec873f01e7645f8e47112f101c0b3d",
-        "8b41b5e5278b263b7206b8ecd44cb764",
-        "8c1c4582dc4c98cc9f41b7aa6479cde6",
-        "e7f5a5fdee6e2899628b6c0c7088c832",
-        "5200dc9a0353fcf76d58d2ccee3bccfb",
-        "309e812a53453f79a90b4a24b6f2f2bd",
-        "3f4a16cd10c7522c0c5b9b51addf4a67",
-        "12347b9168e4eda4bc133d42e3b7edae",
-        "fa66c5abf44505a65b574f0e623f547a",
-        "9eb259384b0b08b034e1de5c751aab6e",
-        "9fb29f6ecb2608ffa81cf8acbef983a8",
-        "06c623a1dfffaf611c463ba1e7d2afd0",
-        "3595226d250799a4ff43ce14d895cd70",
-        "cf66bae88f59bc35dde92c79f8f42d1f",
-        "e3d5f99d7b9af9aa69f7ff6e6aca9d13",
-        "95353b9ec4866802f2d64fbbbeeff34f",
-        "f78b1e4a33e3c9e9ee28c2a352009a44",
-        "2118a5b58c4307b48dc272ea40056db7",
-        "76b0097ed4c68b3fb3109eed4510803a",
-        "1f6c80e4cf1ef217a0a079b8ed8af50b",
-        "314ca0b85eb36b7d94506a4e9a0a3a74",
-        "f95a1937ee1bc820524c7b96cee8331a",
-        "a9c2778b4c48d7203afb28365ecbe7bd",
-        "7a85bf46f4f83079cee966a2ed127208",
-        "f1f971229e9825c34a1958221276f584",
-        "604d2e29cf8d1c0ef6897d0d251a76de",
-        "3c84c249a6ea33b86da4d406b3952715",
-        "ea62aa12752e4e57b956264f80c661d2",
-        "02efbf0bb53a747ac72803ac6e332f67",
-        "aea99437e60f8d90af3c72469c8dcf0c",
-        "9a8f61648d7322904d960442fcea0375",
-        "f25eea5929eec6cfbed80dedd1402890",
-        "38939f3cc8ff11147436a894729aeeb3",
-        "21f95b20e7c98609fc66c8652a86a6b8",
-        "e16dd62a706188f6a839bc085d7de929",
-        "7cf96872e6156106809e8d454a58ff1d",
-        "e61c1d83e8242bc8c1bfa8778f383cdc",
-        "b2c173a0879e88bb279e3e2d2b7f8344",
-        "d18d2247d53d4a6c281c4a9417004baf",
-        "b8c574146addd5538d925e190f43d649",
-        "ac3e2c039f761fb5a87a342d0c0bcb5b",
-        "b9f45a4bc2ca6b7845b48217abc18b61",
-        "a5234140e59c48d01ba9d513e5ddc59e",
-        "91ab77778e80438ac943ecff08cb8fac",
-        "4f0f21eadd53dc1a95cab990c1e63b6b",
-        "b230bae4eaaddebc1d90dfaca334b71c",
-        "eb0175694bef59f9576e5f9e928cf4bf",
-        "3e97426841e285f44105f818f70761b9",
-        "6c062833c33031566433a90027266215",
-        "a9d0b7fbb1bfe438d276983a45510afe",
-        "ebe4ec3c1e634e338aae955684984f8e",
-        "56e41a611051b3e68d21edf68b957a5f",
-        "602f3dbdc77fdd01f25e67807e1b6bc3",
-        "5e11e867a1c3d16b6f95e96725ee9147",
-        "0770082acc38b496faf09760fe3e32e9",
-        "4c17fb20756b6f4c876502d1e8593f18",
-        "60fc7c36c91e6e00a422fa0a89b6fe4e",
-        "26889a42df8f4c0da5aec81a23407449",
-        "b89d82da441a47ea2cf272c93afe321f",
-        "092a7f792fc4682650cd41f06c33ba13",
-        "57fbd6cc885600cfb3c16ff24ec77be4",
-        "2ce3d980588e453e30d1cb24dce48973",
-        "a00915a4b25bd93c1430f9506c1fab42",
-        "a73513cd1c97a39c16d7ef16e5acc193",
-        "e282d5813c40d2cc4ecb5dd718e07bee",
-        "120fe20ba5923de1863f3a6a520eabed",
-        "5ff8eff57cf75b7245e010012d66d3b9",
-        "134de2b4de2a562ed8d788b10b67039b",
-        "d05f3df2271c3e091b306a78bd5d071b",
-    ]
 
     # mirrors = ["https://engineering.case.edu/sites/default/files"]
     # resources = [(name, md5_value) for name, md5_value in zip(ALLNAMES, MD5SUMS)]
     # https://drive.google.com/file/d/1G2vfms1QDlkdzqL_LAQdMIQAoludxBNj/view?usp=sharing
-    mirrors = ["1G2vfms1QDlkdzqL_LAQdMIQAoludxBNj"]
-    resources = [("CWRU.zip", "d7d3042161080fc82e99d78464fa2914")]
+    gdrive_counterpart = {
+        "filename": "CWRU.zip",
+        "md5": "d7d3042161080fc82e99d78464fa2914",
+        "id": "1G2vfms1QDlkdzqL_LAQdMIQAoludxBNj",
+    }
+    source = [
+        "https://engineering.case.edu/bearingdatacenter/normal-baseline-data",
+        "https://engineering.case.edu/bearingdatacenter/48k-drive-end-bearing-fault-data",
+        "https://engineering.case.edu/bearingdatacenter/12k-drive-end-bearing-fault-data",
+        "https://engineering.case.edu/bearingdatacenter/48k-drive-end-bearing-fault-data",
+        "https://engineering.case.edu/bearingdatacenter/12k-fan-end-bearing-fault-data"
+    ]
+    dir_md5 = "b8c2b518389a7a345a6c0a1fa672aff5"
 
-    # resources = [('97.mat', 'ee410e7243aefcd8b7120876556464e7')]
-
-    def __init__(self, root_dir: str, download=False):
-        if download:
-            # print(f"Downloading {self.name()}")
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=CWRU_raw.resources,
-                download_urls=CWRU_raw.mirrors,
-                extract_files=True,
-            )
-        else:
-            super().__init__(root_dir=root_dir, download_resources=CWRU_raw.resources)
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
 
     def __getitem__(self, i) -> dict:
         if not hasattr(i, "__len__") and not isinstance(i, slice):
@@ -325,6 +75,32 @@ class CWRU_raw(RawVibrationDataset, DownloadableDataset):
             dict_labels = {id_label: labels_name for id_label, labels_name, _ in dataset_labels.itertuples(index=False)}
             df["label"] = df["label"].apply(lambda id_label: dict_labels[id_label])
         return df
+
+    def download(self) -> None:
+        """
+        Override the download method, applying the download directly from the source instead of the google drive
+        """
+        # Fetch the urls from each file if download from source
+        if self.download_from_source:
+            files_endpoints = []
+
+            for src in self.source:
+                try:
+                    response = requests.get(src)
+                    response.raise_for_status()
+
+                    soup = BeautifulSoup(response.content, 'html.parser')
+                    table = soup.find('table')
+                    matches = re.findall("https://.*mat", str(table))
+                    files_endpoints.extend(matches)
+                    
+                except requests.HTTPError as e:
+                    print(f"Failed to download the {self.name} Dataset from the source. Please ensure the endpoint is working.\n{str(e)}")
+                    raise e
+
+            # update the self.source with the actually files urls
+            self.source = files_endpoints
+        super().download()
 
     def name(self):
         return "CWRU"

--- a/vibdata/raw/HUST/HUST.py
+++ b/vibdata/raw/HUST/HUST.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 from urllib.error import URLError
 
 from gdown import download
+import shutil
 
 import numpy as np
 import pandas as pd
@@ -14,20 +15,17 @@ import scipy
 
 class HUST_raw(RawVibrationDataset, DownloadableDataset):
 
-    mirrors = [""]
-    resources = [("HUST.zip", "47441ac9bf782c592d63a6174d3d7d7e")]
-    source = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/cbv7jyx4p9-2.zip"
+    gdrive_counterpart = {
+        "filename": "HUST.zip",
+        "md5": "51414ffba877ce602147e09e21b38a51",
+        "id": "1G7Z7SIIvQungvvrVup7r1wy_7s5rv5Y5",
+    }
+    source = ["https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/cbv7jyx4p9-2.zip"]
+    dir_md5 = "53cb1dfa329a493dcd357eb7f9c8be32"
 
-    def __init__(self, root_dir: str, download : bool = False) -> None:
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=HUST_raw.resources,
-                download_urls=HUST_raw.mirrors,
-                extract_files=True,
-            )
-        else:
-            super().__init__(root_dir=root_dir, download_resources=HUST_raw.resources)
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
+
 
     def __getitem__(self, index : slice | int ) -> dict:
         # TODO: Pensar se vai realmenter manter o retorno como uma lista
@@ -71,25 +69,15 @@ class HUST_raw(RawVibrationDataset, DownloadableDataset):
     def name(self):
         return "HUST"
     
+    def download(self)-> None:
+        super().download()
+        # post-processing
+        # organizing structure to follow standard
+        inter_dir = "cbv7jyx4p9-2" if self.download_from_source else ""
+        source_dir = os.path.join(self.raw_folder, inter_dir, "HUST bearing")
+        aux_dir = os.path.join(os.path.dirname(self.raw_folder), "HUST_aux")
 
-    def download(self) -> None:
-        """
-        Override the download method, applying the download directly from the source instead of the google drive
-        """
-        if self._check_exists():
-            return
-
-        os.makedirs(self.raw_folder, exist_ok=True)
-        try:
-            zip_path = os.path.join(self.raw_folder, self.name() + ".zip")
-            download(self.source, output=zip_path)
-            extract_archive_and_remove(zip_path, self.raw_folder)
-            # Rename directory to match the default pattern
-            os.rename(
-                os.path.join(self.raw_folder, "HUST bearing"), 
-                os.path.join(self.raw_folder, self.name())
-            )
-        except URLError as error:
-            print("Failed to download:\n{}".format(error))
-        finally:
-            print()
+        shutil.move(source_dir, aux_dir)
+        shutil.rmtree(self.raw_folder)
+        os.rename(aux_dir, self.raw_folder)
+            

--- a/vibdata/raw/HUST/HUST.py
+++ b/vibdata/raw/HUST/HUST.py
@@ -72,7 +72,7 @@ class HUST_raw(RawVibrationDataset, DownloadableDataset):
     def download(self)-> None:
         super().download()
         # post-processing
-        # organizing structure to follow standard
+        # organize structure to follow standard
         inter_dir = "cbv7jyx4p9-2" if self.download_from_source else ""
         source_dir = os.path.join(self.raw_folder, inter_dir, "HUST bearing")
         aux_dir = os.path.join(os.path.dirname(self.raw_folder), "HUST_aux")

--- a/vibdata/raw/IMS/IMS.py
+++ b/vibdata/raw/IMS/IMS.py
@@ -3,9 +3,10 @@ import os
 
 import numpy as np
 import pandas as pd
+import shutil
 
 from vibdata.raw.base import DownloadableDataset, RawVibrationDataset
-from vibdata.raw.utils import _get_package_resource_dataframe
+from vibdata.raw.utils import _get_package_resource_dataframe, extract_archive_and_remove
 from vibdata.definitions import LABELS_PATH
 
 # This dataset are composed by three tests each one describing a test-to-failure experiment.
@@ -64,10 +65,14 @@ from vibdata.definitions import LABELS_PATH
 
 
 class IMS_raw(RawVibrationDataset, DownloadableDataset):
-    source = "https://drive.google.com/file/d/1r9SadjRcUkvI1wJZvi-nu9VzPyQ8oOvE/view?usp=sharing"
 
-    urls = mirrors = ["1r9SadjRcUkvI1wJZvi-nu9VzPyQ8oOvE"]  # Google drive id
-    resources = [("IMS.zip", "4d24ffef04f5869d68c0bc7cf65ebf77")]
+    gdrive_counterpart = {
+        "filename": "IMS.zip", 
+        "md5": "4d24ffef04f5869d68c0bc7cf65ebf77", 
+        "id": "1r9SadjRcUkvI1wJZvi-nu9VzPyQ8oOvE"
+    }
+    source = ["https://data.nasa.gov/docs/legacy/IMS.zip"]
+    dir_md5 = "346c8759b14b9a0a977e5c03539c2cd8"
 
     #
     # Data file organization
@@ -89,20 +94,8 @@ class IMS_raw(RawVibrationDataset, DownloadableDataset):
     #
     #              }
 
-    def __init__(self, root_dir: str, download=False, with_thirdtest=False):
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=IMS_raw.resources,
-                download_urls=IMS_raw.urls,
-                extract_files=True,
-            )
-        else:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=IMS_raw.resources,
-                download_mirrors=None,
-            )
+    def __init__(self, root_dir: str, download_from_source=False, with_thirdtest=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
         self.third_test = with_thirdtest
 
     def _get_test_folder(self, ntest: int) -> str:
@@ -164,3 +157,30 @@ class IMS_raw(RawVibrationDataset, DownloadableDataset):
 
     def name(self):
         return "IMS"
+
+    def download(self) -> None:
+        super().download()
+
+        # post-processing
+        if self.download_from_source:
+            # organize structure to follow standard
+            source_dir = os.path.join(self.raw_folder, "IMS", "IMS")
+            aux_dir = os.path.join(os.path.dirname(self.raw_folder), "IMS_aux")
+
+            shutil.move(source_dir, aux_dir)
+            shutil.rmtree(self.raw_folder)
+            os.rename(aux_dir, self.raw_folder) 
+
+            print("Extracting subdirectories ...")
+            # extract the compressed arquives
+            for test_file in filter(lambda f: f.endswith('.rar'), os.listdir(self.raw_folder)):
+                extract_archive_and_remove(os.path.join(self.raw_folder, test_file))
+    
+            # in order to keep the pattern from the gdrive counterpart need to remove the pdf
+            os.remove(os.path.join(self.raw_folder, "Readme Document for IMS Bearing Data.pdf"))
+            # for some reason the 3rd test has a nested directory and the wrong name
+            source_dir = os.path.join(self.raw_folder, "4th_test", "txt")
+            target_dir = os.path.join(self.raw_folder, "3rd_test")
+            shutil.move(source_dir, target_dir)
+            shutil.rmtree(os.path.dirname(source_dir))
+                

--- a/vibdata/raw/MFPT/MFPT.py
+++ b/vibdata/raw/MFPT/MFPT.py
@@ -73,8 +73,7 @@ class MFPT_raw(RawVibrationDataset, DownloadableDataset):
             # organizing directory in the correct structure
             source_dir = os.path.join(self.raw_folder, "MFPT-Fault-Data-Sets-20200227T131140Z-001/MFPT Fault Data Sets")
             aux_dir = os.path.join(os.path.dirname(self.raw_folder), "MFPT_aux")
-            target_dir = os.path.join(os.path.dirname(self.raw_folder), "MFPT")
             
             shutil.move(source_dir, aux_dir)
-            shutil.rmtree(target_dir)
-            os.rename(aux_dir, target_dir)
+            shutil.rmtree(self.raw_folder)
+            os.rename(aux_dir, self.raw_folder)

--- a/vibdata/raw/MFPT/MFPT.py
+++ b/vibdata/raw/MFPT/MFPT.py
@@ -9,6 +9,7 @@ from scipy.io import loadmat
 from vibdata.raw.base import DownloadableDataset, RawVibrationDataset
 from vibdata.raw.utils import extract_archive_and_remove, _get_package_resource_dataframe
 from vibdata.definitions import LABELS_PATH
+import shutil
 
 
 class MFPT_raw(RawVibrationDataset, DownloadableDataset):
@@ -17,24 +18,16 @@ class MFPT_raw(RawVibrationDataset, DownloadableDataset):
     """
 
     # mirrors = ["https://www.mfpt.org/wp-content/uploads/2020/02/"]
-    urls = ["1VxGlOMCEED7jy2qAoE9nKYAK8h5i6TIb"]
-    resources = [("MFPT.zip", "4631f552c6a0769996ee1d09e5feb209")]
-    root_dir = "MFPT Fault Data Sets"
+    gdrive_counterpart = {
+        "filename": "MFPT.zip",
+        "md5": "4631f552c6a0769996ee1d09e5feb209",
+        "id": "1VxGlOMCEED7jy2qAoE9nKYAK8h5i6TIb",
+    }
+    source = ["https://www.mfpt.org/wp-content/uploads/2020/02/MFPT-Fault-Data-Sets-20200227T131140Z-001.zip"]
+    dir_md5 = "5ca1781103c2c7e892556d3611193d1c"
 
-    def __init__(self, root_dir: str, download=False):
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=MFPT_raw.resources,
-                download_urls=MFPT_raw.urls,
-                extract_files=True,
-            )
-        else:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=MFPT_raw.resources,
-                download_urls=None,
-            )
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
 
     def __getitem__(self, i) -> dict:
         if not hasattr(i, "__len__") and not isinstance(i, slice):
@@ -72,3 +65,16 @@ class MFPT_raw(RawVibrationDataset, DownloadableDataset):
 
     def name(self):
         return "MFPT"
+
+    def download(self) -> None:
+        super().download()
+        # post processing when downloading from source
+        if self.download_from_source:
+            # organizing directory in the correct structure
+            source_dir = os.path.join(self.raw_folder, "MFPT-Fault-Data-Sets-20200227T131140Z-001/MFPT Fault Data Sets")
+            aux_dir = os.path.join(os.path.dirname(self.raw_folder), "MFPT_aux")
+            target_dir = os.path.join(os.path.dirname(self.raw_folder), "MFPT")
+            
+            shutil.move(source_dir, aux_dir)
+            shutil.rmtree(target_dir)
+            os.rename(aux_dir, target_dir)

--- a/vibdata/raw/PU/PU.py
+++ b/vibdata/raw/PU/PU.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 from scipy.io import loadmat
+import requests
+from bs4 import BeautifulSoup
+import re
 
 from vibdata.raw.base import DownloadableDataset, RawVibrationDataset
 from vibdata.raw.utils import _get_package_resource_dataframe
@@ -17,34 +20,19 @@ class PU_raw(RawVibrationDataset, DownloadableDataset):
     """
 
     # mirrors = ["http://groups.uni-paderborn.de/kat/BearingDataCenter"]
-    # resources = [('K001.rar', None), ('K005.rar', None), ('KA04.rar', None), ('KA08.rar', None),
-    #              ('KA22.rar', None), ('KB27.rar', None), ('KI05.rar', None), ('KI16.rar', None),
-    #              ('K002.rar', None), ('K006.rar', None), ('KA05.rar', None), ('KA09.rar', None),
-    #              ('KA30.rar', None), ('KI01.rar', None), ('KI07.rar', None), ('KI17.rar', None),
-    #              ('K003.rar', None), ('KA01.rar', None), ('KA06.rar', None), ('KA15.rar', None),
-    #              ('KB23.rar', None), ('KI03.rar', None), ('KI08.rar', None), ('KI18.rar', None),
-    #              ('K004.rar', None), ('KA03.rar', None), ('KA07.rar', None), ('KA16.rar', None),
-    #              ('KB24.rar', None), ('KI04.rar', None), ('KI14.rar', None), ('KI21.rar', None)]
+    gdrive_counterpart = {
+        "filename": "PU.zip",
+        "md5": "1beb53c6fb79436895787e094a22302f",
+        "id": "1PZLt3h1x_rjY6EfWV3yNl3FSDWH4o-Ii"
+    }
+    source = ['https://groups.uni-paderborn.de/kat/BearingDataCenter/']
+    dir_md5 = "2ae4fbc4c9cc3601b5ffc30b31364309"
 
-    # https://drive.google.com/file/d/1PZLt3h1x_rjY6EfWV3yNl3FSDWH4o-Ii/view?usp=sharing
-    urls = ["1PZLt3h1x_rjY6EfWV3yNl3FSDWH4o-Ii"]
-    resources = [("PU.zip", "1beb53c6fb79436895787e094a22302f")]
-
-    def __init__(self, root_dir: str, download=False):
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=PU_raw.resources,
-                download_urls=PU_raw.urls,
-                extract_files=True,
-            )
-        else:
-            super().__init__(root_dir=root_dir, download_resources=PU_raw.resources)
-
-        self._metainfo = _get_package_resource_dataframe(__package__, "PU.csv")
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
 
     def getMetaInfo(self, labels_as_str=False) -> pd.DataFrame:
-        df = self._metainfo
+        df = _get_package_resource_dataframe(__package__, "PU.csv")
         if labels_as_str:
             # Create a dict with the relation between the centralized label with the actually label name
             all_labels = pd.read_csv(LABELS_PATH)
@@ -59,7 +47,7 @@ class PU_raw(RawVibrationDataset, DownloadableDataset):
 
         if isinstance(i, slice):
             range_idx = list(range(i.start, i.stop, i.step))
-            data_i = self._metainfo.iloc[i]
+            data_i = self.getMetaInfo().iloc[i]
             fname, bearing_code = data_i["file_name"], data_i["bearing_code"]
             signal_datas = np.empty(len(range_idx), dtype=object)
             for j in range(len(range_idx)):
@@ -69,7 +57,7 @@ class PU_raw(RawVibrationDataset, DownloadableDataset):
 
             return {"signal": signal_datas, "metainfo": data_i}
 
-        data_i = self._metainfo.iloc[i]
+        data_i = self.getMetaInfo().iloc[i]
         fname, bearing_code = data_i["file_name"], data_i["bearing_code"]
 
         if isinstance(i, list):
@@ -105,3 +93,31 @@ class PU_raw(RawVibrationDataset, DownloadableDataset):
 
     def name(self):
         return "PU"
+
+    def download(self):
+        # pre-process
+        if self.download_from_source:
+            # fetch all urls from the files stored at the index source site
+            files_endpoints = []
+            source_url = self.source[0]
+            try:
+                response = requests.get(source_url)
+                response.raise_for_status()
+
+                soup = BeautifulSoup(response.content, 'html.parser')
+                table = soup.find('table')
+                # extract all href attributes from anchor tags in the table
+                hrefs = [link['href'] for link in table.find_all('a', href=True)]
+                r = re.compile("K.*rar")
+                matches = list(filter(r.match, hrefs))
+                matches = list(map(lambda f: os.path.join(source_url, f), matches))
+                files_endpoints.extend(matches)
+                
+            except requests.HTTPError as e:
+                print(f"Failed to download the {self.name} Dataset from the source. Please ensure the endpoint is working.\n{str(e)}")
+                raise e
+
+            # update the self.source with the actually files urls
+            self.source = files_endpoints
+
+        super().download()

--- a/vibdata/raw/UOC/UOC.py
+++ b/vibdata/raw/UOC/UOC.py
@@ -16,24 +16,19 @@ class UOC_raw(RawVibrationDataset, DownloadableDataset):
     LICENSE: Attribution-NonCommercial 4.0 International (CC BY-NC 4.0) [https://creativecommons.org/licenses/by-nc/4.0/]
     """
 
-    urls = ["1oJHir0Faq_kgFnPPMaLSVyBJb6szjEOL"]
-    resources = [("UOC.zip", "c33f1f6117ee4913257086007790df35")]
+    gdrive_counterpart = {
+        "filename": "UOC.zip",
+        "md5": "c33f1f6117ee4913257086007790df35",
+        "id": "1oJHir0Faq_kgFnPPMaLSVyBJb6szjEOL",
+    }
+    source = ["https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/11053469/DataForClassification_TimeDomain.mat"]
+    dir_md5 = "1f1db45f476512c2c17eb60586d71ea6"
 
-    def __init__(self, root_dir: str, download=False):
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=UOC_raw.resources,
-                download_urls=UOC_raw.urls,
-                extract_files=True,
-            )
-        else:
-            super().__init__(root_dir=root_dir, download_resources=UOC_raw.resources)
-
-        self._metainfo = _get_package_resource_dataframe(__package__, "UOC.csv")
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
 
     def getMetaInfo(self, labels_as_str=False) -> pd.DataFrame:
-        df = self._metainfo
+        df = _get_package_resource_dataframe(__package__, "UOC.csv")
         if labels_as_str:
             # Create a dict with the relation between the centralized label with the actually label name
             all_labels = pd.read_csv(LABELS_PATH)

--- a/vibdata/raw/UORED/UORED.py
+++ b/vibdata/raw/UORED/UORED.py
@@ -1,33 +1,27 @@
 import os
 from typing import List, Tuple
-from urllib.error import URLError
-
-from gdown import download
 
 import numpy as np
 import pandas as pd
-import requests
 from vibdata.raw.base import DownloadableDataset, RawVibrationDataset
-from vibdata.raw.utils import _get_package_resource_dataframe, extract_archive_and_remove
+from vibdata.raw.utils import _get_package_resource_dataframe
 from vibdata.definitions import LABELS_PATH
 import scipy
+import shutil
 
 class UORED_raw(RawVibrationDataset, DownloadableDataset):
 
-    mirrors = [""]
-    resources = [("UORED.zip", "9c6e86e4dc2f741a4c3f016fd5ec93d0")]
-    source = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/y2px5tg92h-4.zip"
+    gdrive_counterpart = {
+        "filename": "UORED.zip",
+        "md5": "9c6e86e4dc2f741a4c3f016fd5ec93d0",
+        "id": "1Scn0jc-d7BiHOvN1xzAYcTM3RUTJbPGq"
+    }
+    source = ["https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/y2px5tg92h-4.zip"]
+    dir_md5 = "4f66893185402664625ce595b1badce9"
 
-    def __init__(self, root_dir: str, download : bool = False) -> None:
-        if download:
-            super().__init__(
-                root_dir=root_dir,
-                download_resources=UORED_raw.resources,
-                download_urls=UORED_raw.mirrors,
-                extract_files=True,
-            )
-        else:
-            super().__init__(root_dir=root_dir, download_resources=UORED_raw.resources)
+    def __init__(self, root_dir: str, download_from_source=False):
+        super().__init__(root_dir=root_dir, download_gdrive=self.gdrive_counterpart, download_from_source=download_from_source)
+
 
     def __getitem__(self, index : slice | int ) -> dict:
         # TODO: Pensar se vai realmenter manter o retorno como uma lista
@@ -73,23 +67,16 @@ class UORED_raw(RawVibrationDataset, DownloadableDataset):
     
 
     def download(self) -> None:
-        """
-        Override the download method, applying the download directly from the source instead of the google drive
-        """
-        if self._check_exists():
-            return
+        super().download()
 
-        os.makedirs(self.raw_folder, exist_ok=True)
-        try:
-            zip_path = os.path.join(self.raw_folder, self.name() + ".zip")
-            download(self.source, output=zip_path)
-            extract_archive_and_remove(zip_path, self.raw_folder)
-            # Rename directory to match the default pattern
-            os.rename(
-                os.path.join(self.raw_folder, "University of Ottawa Rolling-element Dataset – Vibration and Acoustic Faults under Constant Load and Speed conditions (UORED-VAFCLS)"), 
-                os.path.join(self.raw_folder, self.name())
-            )
-        except URLError as error:
-            print("Failed to download:\n{}".format(error))
-        finally:
-            print()
+        # post-processing
+        # organize structure to follow standard
+
+        inter_dir = "y2px5tg92h-4" if self.download_from_source else ""
+        source_dir = os.path.join(self.raw_folder, inter_dir, "University of Ottawa Rolling-element Dataset – Vibration and Acoustic Faults under Constant Load and Speed conditions (UORED-VAFCLS)")
+        aux_dir = os.path.join(os.path.dirname(self.raw_folder), "UORED_aux")
+
+        shutil.move(source_dir, aux_dir)
+        shutil.rmtree(self.raw_folder)
+        os.rename(aux_dir, self.raw_folder)
+            

--- a/vibdata/raw/base.py
+++ b/vibdata/raw/base.py
@@ -5,8 +5,10 @@ from urllib.error import URLError
 
 import numpy as np
 import pandas as pd
+import requests
 
-from vibdata.raw.utils import extract_archive_and_remove, download_file_from_google_drive
+
+from vibdata.raw.utils import extract_archive_and_remove, download, _ARCHIVE_EXTRACTORS, _compute_md5_dir
 from vibdata.definitions import LABELS_PATH
 
 
@@ -14,10 +16,8 @@ class DownloadableDataset:
     def __init__(
         self,
         root_dir: str,
-        download_resources: List[Tuple[str, str]],
-        download_mirrors: List = None,
-        download_urls: List = None,
-        extract_files=False,
+        download_gdrive: Dict[str, str],
+        download_from_source : bool,
     ) -> None:
         """
         This class does not download the dataset if files are already present and their md5 hash (if available) are correct.
@@ -32,34 +32,29 @@ class DownloadableDataset:
         """
 
         self.root_dir = root_dir
-        self.download_resources = download_resources
-        self.download_mirrors = download_mirrors
-        self.download_urls = download_urls
-        self.extract_files = extract_files
+        self.download_gdrive = download_gdrive
+        self.download_from_source = download_from_source
         self.download_done = False
         if not self._check_exists():
             self.download()
             if not self._check_exists():
+                # TODO: Update this error message
                 raise RuntimeError("Dataset not found. You can use download=True to download it.")
         self.download_done = True
 
     @property
     def raw_folder(self) -> str:
-        if self.download_done:
-            return os.path.join(
-                self.root_dir,
-                self.__class__.__name__,
-                self.download_resources[0][0][:-4],
-            )
-        else:
-            return os.path.join(self.root_dir, self.__class__.__name__)
+        return os.path.join(
+            self.root_dir,
+            self.__class__.__name__,
+            self.name(),
+        )
 
     def _check_exists(self) -> bool:
-        for url, _ in self.download_resources:
-            fpath = os.path.join(self.raw_folder, url[:-4])
-            if not os.path.isdir(fpath):
-                return False
-        return True
+        if os.path.isdir(self.raw_folder):
+            # compute md5sum
+            return self.dir_md5 == _compute_md5_dir(self.raw_folder)
+        return False
 
     def download(self) -> None:
         """Download the dataset, if it doesn't exist already."""
@@ -67,40 +62,39 @@ class DownloadableDataset:
         if self._check_exists():
             return
 
-        os.makedirs(self.raw_folder, exist_ok=True)
-
-        # download files
-        if self.download_urls is None:
-            urls_list = [
-                [f"{mirror}/{filename}" for filename, _ in self.download_resources] for mirror in self.download_mirrors
-            ]
-        else:
-            if isinstance(self.download_urls[0], str):
-                urls_list = [self.download_urls]
-            else:
-                urls_list = self.download_urls
-
-        for i, (filename, md5) in enumerate(self.download_resources):
-            for url_mirror in urls_list:
-                url = url_mirror[i]
+        if self.download_from_source:
+            # download all files in self.source
+            # use same session to avoid overhead
+            session = requests.Session()
+            os.makedirs(self.raw_folder, exist_ok=True)
+            for url in self.source:
                 try:
-                    if self.extract_files:
-                        download_file_from_google_drive(url, root=self.raw_folder, filename=filename, md5=md5)
-                        extract_archive_and_remove(
-                            self.raw_folder + f"/{filename}",
-                            self.raw_folder + f"/{filename[:-4]}",
-                        )
-                    else:
-                        download_file_from_google_drive(url, root=self.raw_folder, filename=filename, md5=md5)
-                except URLError as error:
-                    print("Failed to download:\n{}".format(error))
-                    continue
-                finally:
-                    print()
-                break
-            else:
-                raise RuntimeError("Error downloading {}".format(filename))
-
+                    output_path = os.path.join(self.raw_folder, os.path.basename(url))
+                    download(url, output_path, session=session, chunk_size=1024)
+                    ext = os.path.basename(url)[-4:]
+                    # in case is a compressed file and exist an extractor for it
+                    if ext in _ARCHIVE_EXTRACTORS.keys():
+                        extract_archive_and_remove(output_path, output_path[:-4])
+                    print(f"Download of {url} done")
+                except Exception as error:
+                    print("Error downloading {}".format(url))      
+                    raise error         
+        else:
+            # download from the google drive
+            url_base = "https://drive.google.com/uc?id="
+            full_url = url_base + self.download_gdrive["id"]
+            
+            # create all directories before `{dataset_name}` as it will be created when 
+            # file is extracted
+            root = os.path.dirname(self.raw_folder)
+            os.makedirs(root, exist_ok=True)
+            output_path = os.path.join(root, self.download_gdrive["filename"])
+            try:
+                download(full_url, output_path, md5=self.download_gdrive["md5"])
+                extract_archive_and_remove(output_path, output_path[:-4])
+            except URLError as error:
+                raise RuntimeError("Error downloading {}".format(full_url))
+        
 
 class RawVibrationDataset:
     def __iter__(self):

--- a/vibdata/raw/utils.py
+++ b/vibdata/raw/utils.py
@@ -7,8 +7,12 @@ import hashlib
 import os.path
 import pathlib
 import tarfile
+import urllib
 import zipfile
 from typing import IO, Any, Dict, Tuple, Callable, Optional
+import requests
+from tqdm import tqdm
+import time
 
 import gdown
 import pandas as pd
@@ -19,6 +23,32 @@ try:
 except ImportError:
     from pkg_resources import resource_stream as resources_path
 
+
+def retry(func, tries=3, delay=2, backoff=1, **kwargs):
+    for attempt in range(tries):
+        try:
+            return func(**kwargs)
+        except Exception as e:
+            if attempt < tries - 1:
+                time.sleep(delay)
+                delay *= backoff
+            else:
+                print(f"Max retries ({tries}) exceeded of the func {func.__name__} with args {str(kwargs)}")                
+                raise e
+
+def _compute_md5_dir(dir_path : str):
+    # this is a fast way to check wheter there are changes in the data directory, but does not guarantee if the 
+    # files content or structure has been modified
+    files = sorted(os.listdir(dir_path))
+    dir_desc = \
+    '''
+    {}
+    {}
+    '''.format(len(files), files)
+    md5_hash = hashlib.md5()
+    md5_hash.update(dir_desc.encode('utf-8'))
+    md5_digest = md5_hash.hexdigest()
+    return md5_digest
 
 def _get_package_resource_dataframe(
     package: str,
@@ -67,7 +97,7 @@ def check_integrity(fpath: str, md5: Optional[str] = None) -> bool:
     return check_md5(fpath, md5)
 
 
-def download_file_from_google_drive(file_id: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None):
+def download_file_from_google_drive(file_id: str, output: str, md5: Optional[str] = None):
     """Download a Google Drive file from  and place it in root.
     Args:
         file_id (str): id of file to be downloaded
@@ -75,12 +105,8 @@ def download_file_from_google_drive(file_id: str, root: str, filename: Optional[
         filename (str, optional): Name to save the file under. If None, use the id of the file.
         md5 (str, optional): MD5 checksum of the download. If None, do not check
     """
-    root = os.path.expanduser(root)
-    if filename is None:
-        filename = file_id
-    fpath = os.path.join(root, filename)
-
-    os.makedirs(root, exist_ok=True)
+    #TODO: Update docs
+    fpath = os.path.expanduser(output)
 
     if check_integrity(fpath, md5):
         print(f"Using downloaded {'and verified ' if md5 else ''}file: {fpath}")
@@ -89,6 +115,32 @@ def download_file_from_google_drive(file_id: str, root: str, filename: Optional[
     url_base = "https://drive.google.com/uc?id="
     gdown.cached_download(url=url_base + file_id, path=fpath, md5=md5)
 
+def download_usual_file(url: str, output_path: str, session, chunk_size=512 * 1024): # chunck size of 512kB
+    # TODO: Create docs
+    # based on https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51
+    resp = session.get(url, stream=True)
+    total = int(resp.headers.get('content-length', 0))
+    with open(output_path, 'wb') as file, tqdm(
+        desc=f"From: {url}\tTo: {output_path}\t",
+        total=total,
+        unit='iB',
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
+        for data in resp.iter_content(chunk_size=chunk_size):
+            size = file.write(data)
+            bar.update(size)
+
+def download(url: str, output_path: str, session: requests.Session = None, **kwargs):
+    # TODO: Create docs
+    sess = session if session is not None else requests.Session()
+    gdrive_file_id, _ = gdown.parse_url.parse_url(url)
+
+    if isinstance(gdrive_file_id, bool) and not gdrive_file_id:
+        retry(download_usual_file, tries=10, url=url, output_path=output_path, session=sess, **kwargs)
+    else:
+        # retry and session policy is already native to gdown
+        download_file_from_google_drive(file_id=gdrive_file_id, output=output_path, **kwargs)
 
 def _extract_tar(from_path: str, to_path: str, compression: Optional[str]) -> None:
     with tarfile.open(from_path, f"r:{compression[1:]}" if compression else "r") as tar:


### PR DESCRIPTION
## Summary

Refactored download functionality for raw datasets to support dual-source downloads: Google Drive (fast, pre-packaged) and direct from original sources. This improves flexibility, reliability, and code maintainability.

## Key Changes

### Core Infrastructure
- **`vibdata/raw/base.py`** & **`vibdata/raw/utils.py`**: Redesigned download system to support multiple sources with improved error handling and modularity

### Dataset Modules
All raw dataset modules updated with dual-download support:
- **CWRU**, **HUST**, **IMS**, **MFPT**, **PU**, **UOC**, **UORED**

### Documentation
- **README.md**: Fixed incorrect numerical reference
- Minor typo corrections in code comments

